### PR TITLE
Enable in derived modes of `page-break-lines-modes'

### DIFF
--- a/page-break-lines.el
+++ b/page-break-lines.el
@@ -122,7 +122,7 @@ horizontal line of `page-break-string-char' characters."
 When `major-mode' is listed in `page-break-lines-modes', then
 `page-break-lines-mode' will be enabled."
   (if (and (not (minibufferp (current-buffer)))
-           (memq major-mode page-break-lines-modes))
+           (apply 'derived-mode-p page-break-lines-modes))
       (page-break-lines-mode 1)))
 
 ;;;###autoload


### PR DESCRIPTION
For example if `page-break-lines-modes` contains `prog-mode`,
`global-page-break-lines-mode` will apply to `python-mode`, `c-mode`,
etc.

Tested on Emacs 24.2.
