### PR TITLE
Make mode line indicator customizable

### DIFF
--- a/page-break-lines.el
+++ b/page-break-lines.el
@@ -67,6 +67,11 @@
   :type 'character
   :group 'page-break-lines)
 
+(defcustom page-break-lines-lighter " PgLn"
+  "Mode-line indicator for `page-break-lines-mode'."
+  :type '(choice (const :tag "No lighter" "") string)
+  :group 'page-break-lines)
+
 (defcustom page-break-lines-modes
   '(emacs-lisp-mode lisp-mode scheme-mode compilation-mode outline-mode help-mode)
   "Modes in which to enable `page-break-lines-mode'."
@@ -89,7 +94,7 @@ displayed as a junk character."
 
 In Page Break mode, page breaks (^L characters) are displayed as a
 horizontal line of `page-break-string-char' characters."
-  :lighter " PgLn"
+  :lighter page-break-lines-lighter
   :group 'page-break-lines
   (page-break-lines--update-display-tables))
 


### PR DESCRIPTION
Largely inspired by Magit's lighters, eg for [magit-blame-mode].

Thank you for this package! I like it so much I basically enabled it as globally as I could (ie for fundamental, text, prog and special modes).

(First pull request ever, let me know if I am doing something wrong)

[magit-blame-mode]: https://github.com/magit/magit/blob/4a3d777226c2bec72a9b025ca4d4bdb69c15765b/lisp/magit-blame.el#L77-L80