### PR TITLE
Not to intefere with buffers not in page-break-lines-modes.

### DIFF
--- a/page-break-lines.el
+++ b/page-break-lines.el
@@ -132,7 +132,8 @@ its display table will be modified as necessary."
                    (new-display-entry (vconcat (make-list width glyph))))
               (unless (equal new-display-entry (elt buffer-display-table ?\^L))
                 (aset buffer-display-table ?\^L new-display-entry)))))
-      (when buffer-display-table
+      (when (and (member major-mode page-break-lines-modes)
+                 buffer-display-table)
         (aset buffer-display-table ?\^L nil)))))
 
 (defun page-break-lines--update-display-tables  (&optional frame)


### PR DESCRIPTION
This way, it doesn't interfere with buffers not setup to use page-break-lines.

I created a function to do the same based on your package. It didn't work. After an hour of puzzling, I realized the hooks are wiping out the changes to buffer-display-table formfeed. i.e. as soon as window changed focus, the changes to formfeed display got cleaned.

Thanks!
