### PR TITLE
Autoload customizable variables

### DIFF
--- a/page-break-lines.el
+++ b/page-break-lines.el
@@ -62,22 +62,26 @@
   :prefix "page-break-lines-"
   :group 'faces)
 
+;;;###autoload
 (defcustom page-break-lines-char ?─
   "Character used to render page break lines."
   :type 'character
   :group 'page-break-lines)
 
+;;;###autoload
 (defcustom page-break-lines-lighter " PgLn"
   "Mode-line indicator for `page-break-lines-mode'."
   :type '(choice (const :tag "No lighter" "") string)
   :group 'page-break-lines)
 
+;;;###autoload
 (defcustom page-break-lines-modes
   '(emacs-lisp-mode lisp-mode scheme-mode compilation-mode outline-mode help-mode)
   "Modes in which to enable `page-break-lines-mode'."
   :type '(repeat symbol)
   :group 'page-break-lines)
 
+;;;###autoload
 (defface page-break-lines
   '((t :inherit font-lock-comment-face :bold nil :italic nil))
   "Face used to colorize page break lines.


### PR DESCRIPTION
Whether to autoload customizable variables is a [rather controversial topic](https://emacs.stackexchange.com/a/32860/10269), but I think it's a good idea for:

- Discovery
- Avoiding `void-variable` errors when the user does something like `(cl-pushnew <mode> page-break-lines-modes)` in their init file without `require`-ing `page-break-lines` first.