### PR TITLE
Fix disabling when major mode is derived from one of page-break-lines-modes

### DIFF
--- a/page-break-lines.el
+++ b/page-break-lines.el
@@ -137,7 +137,7 @@ its display table will be modified as necessary."
                      (new-display-entry (vconcat (make-list width glyph))))
                 (unless (equal new-display-entry (elt buffer-display-table ?\^L))
                   (aset buffer-display-table ?\^L new-display-entry)))))
-        (when (and (member major-mode page-break-lines-modes)
+        (when (and (apply 'derived-mode-p page-break-lines-modes)
                    buffer-display-table)
           (aset buffer-display-table ?\^L nil))))))
 


### PR DESCRIPTION
I like this minor mode so much I set page-break-lines-modes to `'(fundamental-mode text-mode prog-mode special-mode)` in an attempt to have it enabled basically everywhere.

For the longest time I was surprised that `M-x page-break-lines-mode` failed to disable the mode: a message (generated by define-minor-mode) told me that it had been disabled, however the ^L glyph was still displayed as a buffer-wide line.

I recently dug into that and if I am not mistaken, this is because I set page-break-lines-modes to these generic parent modes. If I change a buffer's major mode to one of these four, calling `M-x page-break-lines-mode` does revert the line back to ^L.

Does this patch look sound?