### PR TITLE
Max width

### DIFF
--- a/page-break-lines.el
+++ b/page-break-lines.el
@@ -76,6 +76,13 @@
   :group 'page-break-lines)
 
 ;;;###autoload
+(defcustom page-break-lines-max-width nil
+  "If non-nil, maximum width (in characters) of page break indicator.
+If nil, indicator will span the width of the frame."
+  :type '(choice integer (const :tag "Full width" nil))
+  :group 'page-break-lines)
+
+;;;###autoload
 (defcustom page-break-lines-modes
   '(emacs-lisp-mode lisp-mode scheme-mode compilation-mode outline-mode help-mode)
   "Modes in which to enable `page-break-lines-mode'."
@@ -133,6 +140,9 @@ its display table will be modified as necessary."
                                       0)))
                      (width (- (/ wwidth-pix (frame-char-width) cwidth)
                                (if (display-graphic-p) 0 1)))
+                     (width (if page-break-lines-max-width
+                                (min width page-break-lines-max-width)
+                              width))
                      (glyph (make-glyph-code page-break-lines-char 'page-break-lines))
                      (new-display-entry (vconcat (make-list width glyph))))
                 (unless (equal new-display-entry (elt buffer-display-table ?\^L))


### PR DESCRIPTION
Allows the user to specify an optional maximum width for the page break indicator line.

I've personally never been too thrilled about how the lines look when they span my entire screen (nitpicky, I know):

![Screen Shot 2019-05-19 at 4 19 54 PM](https://user-images.githubusercontent.com/141447/57988295-19301800-7a52-11e9-896d-bace56c9d59e.png)

Patch adds an optional maximum width (`page-break-lines-max-width`), taking care not to be wider than the frame itself):

![Screen Shot 2019-05-19 at 4 20 48 PM](https://user-images.githubusercontent.com/141447/57988312-4c72a700-7a52-11e9-9ee8-e5c6c0035ed8.png)
