### PR TITLE
Respect internal window/frame padding

### DIFF
--- a/page-break-lines.el
+++ b/page-break-lines.el
@@ -131,6 +131,8 @@ its display table will be modified as necessary."
                                              (fboundp 'line-number-display-width))
                                         (line-number-display-width t)
                                       0)))
+                     (internal-border-width (or (alist-get 'internal-border-width default-frame-alist) 0))
+                     (wwidth-pix (- wwidth-pix (/ internal-border-width 2)))
                      (width (- (/ wwidth-pix (frame-char-width) cwidth)
                                (if (display-graphic-p) 0 1)))
                      (width (if page-break-lines-max-width


### PR DESCRIPTION
Inspired by https://github.com/rougier/nano-emacs, I have a `internal-border-width` (see [Frame Layout in the manual](https://www.gnu.org/software/emacs/manual/html_node/elisp/Frame-Layout.html)) set to 24:

    (setq default-frame-alist
          (append (list
                   '(font . "Roboto Mono-18")
                   '(min-height . 1)  '(height     . 45)
                   '(min-width  . 1)  '(width      . 101)
                   '(vertical-scroll-bars . nil)
                   '(internal-border-width . 24) ;; frame padding around the text
                   '(left-fringe    . 0)
                   '(right-fringe   . 0))))

I noticed that the effective window width calculations wouldn't work as expected -- as a result, lines would wrap.

This change takes the optional `internal-border-width` into account.

Examples with internal border of 24 and 48, full screen and windowed:

| | before (wrapping/truncating) | after (fits) |
| --- | ---- | --- |
| 24px |  <img id="screenshot2021-10-30at111608" src="https://user-images.githubusercontent.com/59080/139527323-130a2830-34f1-4027-8468-82c973338987.png" /> |  <img id="screenshot2021-10-30at111549" src="https://user-images.githubusercontent.com/59080/139527313-a7ca9adc-783f-4ccc-aed7-9bd45ad6aed3.png" /> |
| 48px |   ![Screen Shot 2021-10-30 at 11 18 09](https://user-images.githubusercontent.com/59080/139527363-8f69659b-16b0-4bcf-9fd8-5fda8c55bc97.png) | ![Screen Shot 2021-10-30 at 11 23 03](https://user-images.githubusercontent.com/59080/139527524-04f847d1-3b59-48a4-999a-cdc20fb3a8c7.png) |

I noticed that I had to `/ 2` the border value, otherwise the line would be truncated too much. Still: the larger the `internal-border-width`, the worse the line actually fits. See the screenshot in the bottom-right at 48px: there's room for 1--2 additional characters.

But I think that's preferable to line-wrapping.