### PR TITLE
fix: error when window width is extremely small

### DIFF
--- a/page-break-lines.el
+++ b/page-break-lines.el
@@ -129,7 +129,7 @@ its display table will be modified as necessary."
                                               (/ (float (string-pixel-width (make-string 100 page-break-lines-char)))
                                                  (string-pixel-width (make-string 100 ?a)))
                                             (char-width page-break-lines-char)))
-                     (width (floor (window-max-chars-per-line) char-relative-width))
+                     (width (floor (max 0 (window-max-chars-per-line)) char-relative-width))
                      (width (if page-break-lines-max-width
                                 (min width page-break-lines-max-width)
                               width))


### PR DESCRIPTION
The function window-max-chars-per-line may return -1 if the width of the current window is extremely small. When -1 is passed as the width value to make-list, it results in an error. We must ensure that the value is non-negative before passing it.