### PR TITLE
Do not select windows when updating display tables

### DIFF
--- a/page-break-lines.el
+++ b/page-break-lines.el
@@ -118,28 +118,27 @@ horizontal line of `page-break-lines-char' characters."
 If the buffer inside WINDOW has `page-break-lines-mode' enabled,
 its display table will be modified as necessary."
   (with-current-buffer (window-buffer window)
-    (with-selected-window window
-      (if page-break-lines-mode
-          (progn
-            (unless buffer-display-table
-              (setq buffer-display-table (make-display-table)))
-            (let ((default-height (face-attribute 'default :height nil 'default)))
-              (set-face-attribute 'page-break-lines nil :height default-height)
-              (let* ((char-relative-width (if (fboundp 'string-pixel-width)
-                                              (/ (float (string-pixel-width (make-string 100 page-break-lines-char)))
-                                                 (string-pixel-width (make-string 100 ?a)))
-                                            (char-width page-break-lines-char)))
-                     (width (floor (max 0 (window-max-chars-per-line)) char-relative-width))
-                     (width (if page-break-lines-max-width
-                                (min width page-break-lines-max-width)
-                              width))
-                     (glyph (make-glyph-code page-break-lines-char 'page-break-lines))
-                     (new-display-entry (vconcat (make-list width glyph))))
-                (unless (equal new-display-entry (elt buffer-display-table ?\^L))
-                  (aset buffer-display-table ?\^L new-display-entry)))))
-        (when (and (apply 'derived-mode-p page-break-lines-modes)
-                   buffer-display-table)
-          (aset buffer-display-table ?\^L nil))))))
+    (if page-break-lines-mode
+        (progn
+          (unless buffer-display-table
+            (setq buffer-display-table (make-display-table)))
+          (let ((default-height (face-attribute 'default :height (window-frame window) 'default)))
+            (set-face-attribute 'page-break-lines nil :height default-height)
+            (let* ((char-relative-width (if (fboundp 'string-pixel-width)
+                                            (/ (float (string-pixel-width (make-string 100 page-break-lines-char)))
+                                               (string-pixel-width (make-string 100 ?a)))
+                                          (char-width page-break-lines-char)))
+                   (width (floor (max 0 (window-max-chars-per-line window)) char-relative-width))
+                   (width (if page-break-lines-max-width
+                              (min width page-break-lines-max-width)
+                            width))
+                   (glyph (make-glyph-code page-break-lines-char 'page-break-lines))
+                   (new-display-entry (vconcat (make-list width glyph))))
+              (unless (equal new-display-entry (elt buffer-display-table ?\^L))
+                (aset buffer-display-table ?\^L new-display-entry)))))
+      (when (and (apply 'derived-mode-p page-break-lines-modes)
+                 buffer-display-table)
+        (aset buffer-display-table ?\^L nil)))))
 
 (defun page-break-lines--update-display-tables  (&optional frame)
   "Function called for updating display table in windows of FRAME."


### PR DESCRIPTION
Selecting windows during minor mode initialization may have
undesirable effects such as resetting a buffer's point to the
window-point of one of the windows it is displayed in.  This can cause
problems when Lisp code wants to use a temp buffer (whose major mode
happens to enable page-break-lines-mode).

For example, when org-babel-insert-result inserts a table result into
an org buffer, it moves point to the place where the result should be
inserted, then calls orgtbl-to-orgtbl (which uses a temp buffer in
org-mode) to calculate the string to insert, and then inserts that
string directly.  If page-break-lines-mode runs in that temp buffer
and causes the original org buffer's window to be selected, that
buffer's point will move and the results will be inserted in the wrong
place.

Fix #45.